### PR TITLE
Fullscreen fix + drag space tweak

### DIFF
--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -49,7 +49,7 @@
     {
         @media (-moz-windows-accent-color-in-titlebar: 0)
         {
-            #main-window:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
+            :root:not([sizemode="fullscreen"]):is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
             {
                 appearance: -moz-win-glass !important;
                 background-color: transparent !important;

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -412,8 +412,15 @@ spacer[part="overflow-end-indicator"]
 {
     :root[sizemode="normal"][tabsintitlebar]
     {
-        --drag-space: 16px;
+        --drag-space: 8px;
     }
+    @supports -moz-bool-pref("userChrome.DragSpaceAboveTabsWindowedMode-Increased") {
+        :root[sizemode="normal"][tabsintitlebar]
+        {
+            --drag-space: 16px !important;
+        }
+    }
+
 }
 
 /* ---------------------------------------- Titlebar ---------------------------------------- */


### PR DESCRIPTION
Two pretty simple changes that should be self explanatory.
- Drag space above tabs reduced to 8px, to match chrome, edge, etc.
(Revert to 16px by setting `userChrome.DragSpaceAboveTabsWindowedMode-Increased` to true)
- `-moz-win-glass` applied only to non-fullscreen windows. Not only the main window now, so PIP windows get rounded corners and some dialogs also receive mica/acrylic