### PR TITLE
Minor fixes  (improved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ By default context menus follow the selected interface density, but it is possib
 - `userChrome.LeftSideDragSpace-Disabled`
 - `userChrome.RightSideDragSpace-Disabled`
 - `userChrome.DragSpaceAboveTabsWindowedMode-Disabled`
+- `userChrome.DragSpaceAboveTabsWindowedMode-Reduced`
 - `userChrome.DragSpaceAboveTabsMaximizedMode-Enabled`
 - `userChrome.DragSpaceAboveTabsFullscreenMode-Enabled`
 

--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -49,7 +49,7 @@
     {
         @media (-moz-windows-accent-color-in-titlebar: 0)
         {
-            #main-window:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
+            #main-window:not([sizemode="fullscreen"]):is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
             {
                 appearance: -moz-win-glass !important;
                 background-color: transparent !important;
@@ -76,6 +76,11 @@
             :root:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]) .titlebar-min
             {
                 border-bottom-left-radius: 8px !important;
+            }
+
+            findbar
+            {
+                background: transparent !important;
             }
         }
     }

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -414,6 +414,13 @@ spacer[part="overflow-end-indicator"]
     {
         --drag-space: 16px;
     }
+    @supports -moz-bool-pref("userChrome.DragSpaceAboveTabsWindowedMode-Reduced")
+    {
+        :root[sizemode="normal"][tabsintitlebar]
+        {
+            --drag-space: 8px;
+        }
+    }
 }
 
 /* ---------------------------------------- Titlebar ---------------------------------------- */


### PR DESCRIPTION
Following previous suggestions, I'm no longer applying -moz-win-glass to all windows (no longer works on PiP as of 105), and drag space is now an option.

So:
- Added - `userChrome.DragSpaceAboveTabsWindowedMode-Decreased` option
- Fixed - Rounded corners appear on fullscreen windows (with mica enabled)
- Fixed - Findbar (control+f) has an incorrect background color (with mica enabled)
