### PR TITLE
Omit seperator before the first visible tab, reduce seperator opacity

### DIFF
--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -775,7 +775,7 @@ spacer[part="overflow-end-indicator"]
     margin-right: 1px !important;
 }
 
-.tabbrowser-tab[first-visible-tab] .tab-stack::before,
+/* .tabbrowser-tab[first-visible-tab] .tab-stack::before, */
 #tabbrowser-tabs[positionpinnedtabs] .tabbrowser-tab[first-visible-unpinned-tab] .tab-stack::before,
 .tab-stack::after
 {
@@ -817,7 +817,7 @@ spacer[part="overflow-end-indicator"]
 {
     :root
     {
-        --separators-color-saturation: 0.5;
+        --separators-color-saturation: 0.15;
     }
 }
 

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -817,7 +817,7 @@ spacer[part="overflow-end-indicator"]
 {
     :root
     {
-        --separators-color-saturation: 0.15;
+        --separators-color-saturation: 0.2;
     }
 }
 


### PR DESCRIPTION
With `userChrome.TabSeparators-Enabled` enabled:
- Updated separator opacity from 0.5 as it is a bit too high. It doesn't much that of Chrome.
- Separator shouldn't go before any tabs. Seems like you tried to do this in the CSS but perhaps didn't realise it wasn't complete.

<details>
    <summary>Before the update</summary>
    <img src=https://user-images.githubusercontent.com/46096865/210115847-e91f47c6-ff7e-4331-993e-9a03f15656b4.png>
    <p>After the update</summary></p>
    <img src=https://user-images.githubusercontent.com/46096865/210115579-b09ea810-2a3d-4925-8614-d6d4016fda53.png>
    <p>Chrome (Chromium) for reference</p>
    <img src=https://user-images.githubusercontent.com/46096865/210115615-b521856f-eada-46c0-878e-503c73e957d3.png>
</details>