### PR TITLE
More elegent solution to Win 11 titlebar buttons

### DIFF
--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -58,9 +58,16 @@
             
             :root[tabsintitlebar]:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]):not([sizemode="fullscreen"]) .titlebar-buttonbox:is(:hover, :hover:active)
             {
-                background-color: Field !important;
-                box-shadow: var(--outer-box-shadow, none) !important;
+            opacity: 0.8 !important;
             }
+		.titlebar-button>.toolbarbutton-icon {
+			margin-top: -14px !important;
+			opacity: 0 !important;
+		}
+		.titlebar-close>.toolbarbutton-icon {
+			margin-top: -14px !important;
+			opacity: 1 !important;
+		}
         }
     }
 

--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -61,13 +61,17 @@
             opacity: 1 !important;
             }
 			.titlebar-button>.toolbarbutton-icon {
-				margin-top: -14px !important;
-				margin-right: 2px !important;
+				margin-top: 1px !important;
+				margin-bottom: 1px !important;
+				margin-right: 1px !important;
 				opacity: 0 !important;
 			}
 			.titlebar-close:hover>.toolbarbutton-icon {
 				opacity: 1 !important;
 			}
+			.titlebar-close:hover {
+				background-color: hsl(5, 75%, 44%) !important 
+}
         }
     }
 

--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -58,7 +58,7 @@
             
             :root[tabsintitlebar]:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]):not([sizemode="fullscreen"]) .titlebar-buttonbox:is(:hover, :hover:active)
             {
-            opacity: 0.8 !important;
+            opacity: 1 !important;
             }
 		.titlebar-button>.toolbarbutton-icon {
 			margin-top: -14px !important;

--- a/chrome/special/windows_11_10.css
+++ b/chrome/special/windows_11_10.css
@@ -58,18 +58,16 @@
             
             :root[tabsintitlebar]:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]):not([sizemode="fullscreen"]) .titlebar-buttonbox:is(:hover, :hover:active)
             {
-
             opacity: 1 !important;
             }
-		.titlebar-button>.toolbarbutton-icon {
-			margin-top: -14px !important;
-			opacity: 0 !important;
-		}
-		.titlebar-close>.toolbarbutton-icon {
-			margin-top: -14px !important;
-			opacity: 1 !important;
-		}
-
+			.titlebar-button>.toolbarbutton-icon {
+				margin-top: -14px !important;
+				margin-right: 2px !important;
+				opacity: 0 !important;
+			}
+			.titlebar-close:hover>.toolbarbutton-icon {
+				opacity: 1 !important;
+			}
         }
     }
 


### PR DESCRIPTION
This is a proposed change to the minimize, expand, and close buttons when the userChrome.Windows.SystemEffects.Enabled flag is set to true. Using a few different methods, this PR fixes the issue in CSS only, meaning that visually, the minimize, expand and close buttons look correct for a more seamless and elegant solution, especially when Mica/transparency effects are used. It might be improved further with some tweaking.

![image](https://github.com/QNetITQ/WaveFox/assets/102811428/b2a31bd0-b91c-4187-beca-ca81f1e5dfa1)
![image](https://github.com/QNetITQ/WaveFox/assets/102811428/b1f2e2be-c70e-4d7b-bb94-f3fa33080eff)
![image](https://github.com/QNetITQ/WaveFox/assets/102811428/dc2778ab-18b6-4e9f-8ea7-91aba8b4b18e)
![image](https://github.com/QNetITQ/WaveFox/assets/102811428/ad7f8aaa-09e9-4a79-86c0-d33713d123fb)
![image](https://github.com/QNetITQ/WaveFox/assets/102811428/abe75b46-658e-4169-bfdb-e01c44412627)

Closes #137
