### PR TITLE
Address FF 119 toolbar change affecting transparency options

### DIFF
--- a/chrome/special/linux.css
+++ b/chrome/special/linux.css
@@ -12,26 +12,39 @@
           -moz-bool-pref("userChrome.Linux.Transparency.High.Enabled")     or
           -moz-bool-pref("userChrome.Linux.Transparency.VeryHigh.Enabled")
 {
+    :root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]):is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]):not(:-moz-window-inactive)
+    {
+        appearance: none !important;
+    }
+
     :root[tabsintitlebar]:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode]):not(:-moz-window-inactive)
     {
         @supports -moz-bool-pref("userChrome.Linux.Transparency.Low.Enabled")
         {
-            background-color: color-mix(in srgb, ActiveCaption 75%, transparent) !important;
+            --titlebar-bgcolor: color-mix(in srgb, ActiveCaption 75%, transparent);
         }
 
         @supports -moz-bool-pref("userChrome.Linux.Transparency.Medium.Enabled")
         {
-            background-color: color-mix(in srgb, ActiveCaption 50%, transparent) !important;
+            --titlebar-bgcolor: color-mix(in srgb, ActiveCaption 50%, transparent);
         }
 
         @supports -moz-bool-pref("userChrome.Linux.Transparency.High.Enabled")
         {
-            background-color: color-mix(in srgb, ActiveCaption 25%, transparent) !important;
+            --titlebar-bgcolor: color-mix(in srgb, ActiveCaption 25%, transparent);
         }
 
         @supports -moz-bool-pref("userChrome.Linux.Transparency.VeryHigh.Enabled")
         {
-            background-color: transparent !important;
+            --titlebar-bgcolor: transparent;
+        }
+
+        background-color: var(--titlebar-bgcolor) !important;
+
+        #navigator-toolbox
+        {
+            appearance: none !important;
+            background-color: var(--titlebar-bgcolor) !important;
         }
 
         #navigator-toolbox-background

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -445,6 +445,27 @@ and
 
 /* ---------------------------------------- Toolbar Transparency ---------------------------------------- */
 
+@supports -moz-bool-pref("userChrome.Toolbar.Transparency.Low.Enabled")      or
+          -moz-bool-pref("userChrome.Toolbar.Transparency.Medium.Enabled")   or
+          -moz-bool-pref("userChrome.Toolbar.Transparency.High.Enabled")     or
+          -moz-bool-pref("userChrome.Toolbar.Transparency.VeryHigh.Enabled")
+{
+    :root[sizemode="normal"]:not([gtktiledwindow="true"]):is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
+    {
+        appearance: none !important;
+    }
+
+    :root:is(:not(:-moz-lwtheme), [lwt-default-theme-in-dark-mode])
+    {
+        background-color: var(--toolbar-bgcolor) !important;
+
+        #navigator-toolbox
+        {
+            appearance: none !important;
+        }
+    }
+}
+
 @supports -moz-bool-pref("userChrome.Toolbar.Transparency.Low.Enabled")    or
           -moz-bool-pref("userChrome.Toolbar.Transparency.Medium.Enabled") or
           -moz-bool-pref("userChrome.Toolbar.Transparency.High.Enabled")


### PR DESCRIPTION
[This](https://phabricator.services.mozilla.com/D187345) was merged into Firefox Nightly 119 yesterday which importantly for us gets rid of the `#navigator-toolbox-background` element and merges some of its properties into `#navigator-toolbox`, breaking the toolbar transparency options.

Code is tested and working on 119 and SHOULD be backwards compatible, but I haven't actually tested backwards compatibility.