### PR TITLE
Add opaque and shadowed inactive tabs

### DIFF
--- a/chrome/modules/horizontal_tabs/wavefox_tab_shadows.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tab_shadows.css
@@ -177,6 +177,10 @@
             {
                 filter: var(--wavefox-selected-tab-shadow) !important;
             }
+            .tabbrowser-tab:not([visuallyselected]) .tab-background
+            {
+                filter: var(--wavefox-selected-tab-shadow) !important;
+            }
 
             /* ---------- AMO ---------- */
             
@@ -381,6 +385,10 @@
             /* ---------- Tabs ---------- */
 
             .tabbrowser-tab[visuallyselected] .tab-background
+            {
+                filter: var(--wavefox-selected-tab-shadow) !important;
+            }
+            .tabbrowser-tab:not([visuallyselected]) .tab-background
             {
                 filter: var(--wavefox-selected-tab-shadow) !important;
             }

--- a/chrome/modules/horizontal_tabs/wavefox_tabs.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tabs.css
@@ -320,16 +320,37 @@
         {
             --tab-loading-fill: currentColor !important;
             --attention-dot-color: currentColor !important;
+            --local-tab-hover-bg-color: var(--tab-hover-background-color);
+            --local-multiselected-tab-bg-color: var(--tab-selected-bgcolor);
+
+            @media (-moz-bool-pref: "userChrome.Tabs.OpaqueInactive.Enabled")
+            {
+                --local-tab-hover-bg-color: color-mix(in srgb, var(--toolbar-bgcolor) 80%, rgb(0, 0, 0)) !important;
+                --local-multiselected-tab-bg-color: color-mix(in srgb, var(--toolbar-bgcolor) 80%, rgb(0, 0, 0)) !important;
+                &:not(:hover) .tab-background {
+                    background-color: color-mix(in srgb, var(--toolbar-bgcolor) 70%, rgb(0, 0, 0)) !important;
+
+                    &::before,
+                    &::after
+                    {
+                        background-color: color-mix(in srgb, var(--toolbar-bgcolor) 70%, rgb(0, 0, 0)) !important;
+                    }
+                }
+            }
             z-index: 0 !important;
 
             &:hover
             {
                 .tab-background
                 {
+                    @media (-moz-bool-pref: "userChrome.Tabs.OpaqueInactive.Enabled")
+                    {
+                        background-color: var(--local-tab-hover-bg-color) !important;
+                    }
                     &::before,
                     &::after
                     {
-                        background-color: var(--tab-hover-background-color) !important;
+                        background-color: var(--local-tab-hover-bg-color) !important;
                     }
                 }
             }
@@ -342,11 +363,15 @@
                 {
                     filter: drop-shadow(0 0 2px var(--focus-outline-color)) !important;
                     backdrop-filter: drop-shadow(0 0 1px transparent) !important;
+                    @media (-moz-bool-pref: "userChrome.Tabs.OpaqueInactive.Enabled")
+                    {
+                        background-color: var(--local-tab-hover-bg-color) !important;
+                    }
 
                     &::before,
                     &::after
                     {
-                        background-color: var(--tab-selected-bgcolor) !important;
+                        background-color: var(--local-multiselected-tab-bg-color) !important;
                         backdrop-filter: drop-shadow(0 0 1px transparent) !important;
                     }
                 }


### PR DESCRIPTION
- Add userChrome.Tabs.OpaqueInactive.Enabled option to enable opaque inactive tabs.
- Add shadows to opaque inactive tabs.
[wavefox-opaque-inactive-tabs.webm](https://github.com/user-attachments/assets/b44e8636-f607-4890-a76e-b34b7ea18ac9)
