### PR TITLE
fix: use `-moz-pref` instead of `-moz-bool-pref`

### DIFF
--- a/chrome/Lepton_Icons/icons/Lepton_Icons.css
+++ b/chrome/Lepton_Icons/icons/Lepton_Icons.css
@@ -1,5 +1,5 @@
 /** Icons *********************************************************************/
-@media not (-moz-bool-pref: "userChrome.icon.disabled") {
+@media not (-moz-pref("userChrome.icon.disabled")) {
   /** Icons - List **************************************************************/
   :root {
     --uc-folder-icon: url("chrome://global/skin/icons/folder.svg");
@@ -25,12 +25,12 @@
   /*= Tor Browser ==============================================================*/
   /*= Floorp Browser ===========================================================*/
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.library")) {
   :root {
     --uc-folder-icon: url("../icons/folder.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.tab.connect_to_window") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.tab.connect_to_window")) {
   :root {
     --uc-tab-icon: url("../icons/tab-photon.svg");
     --uc-tab-copy-icon: url("../icons/tab-copy-photon.svg");
@@ -43,7 +43,7 @@
     --uc-new-tab-skip-forward-icon: url("../icons/new-tab-skip-forward-photon.svg");
   }
 }
-@media not (-moz-bool-pref: "userChrome.icon.disabled") {
+@media not (-moz-pref("userChrome.icon.disabled")) {
   @supports selector(:has(a)) {
     :root:has(#sidebar-box[positionend="true"]) {
       --uc-sidebar-icon: url("chrome://browser/skin/sidebars-right.svg");
@@ -51,18 +51,18 @@
     }
   }
 }
-@media not (-moz-bool-pref: "userChrome.icon.disabled") {
+@media not (-moz-pref("userChrome.icon.disabled")) {
   #TabsToolbar #new-tab-button {
     --uc-new-tab-icon: url(chrome://global/skin/icons/plus.svg);
   }
 }
-@media not (-moz-bool-pref: "userChrome.icon.disabled") {
+@media not (-moz-pref("userChrome.icon.disabled")) {
   .urlbarView-row[source="tabs"] > .urlbarView-row-inner > .urlbarView-no-wrap > .urlbarView-favicon,
   #urlbar-engine-one-off-item-tabs {
     list-style-image: var(--uc-tab-icon) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.library")) {
   /*= Standard Folder - More Visible ===========================================*/
   /* on Toolbar and Menus */
   :-moz-any(#PlacesToolbar, #BMB_bookmarksPopup, #bookmarksMenu)
@@ -188,7 +188,7 @@
   }
   @-moz-document url("chrome://browser/content/places/places.xhtml")
   {
-    @media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.library") and (-moz-gtk-csd-available) {
+    @media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.library")) and (-moz-gtk-csd-available) {
       /*= Menubar - Icons ==========================================================*/
       #organizeButton,
       #viewMenu,
@@ -234,7 +234,7 @@
     }
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   /*= Padding ==================================================================*/
   :root {
     --arrowpanel-menuicon-padding: 8px;
@@ -279,7 +279,7 @@
   /*= Compatibility ============================================================*/
   /*= Tab Mix Plus =============================================================*/
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (not (-moz-bool-pref: "userChrome.icon.panel_full")) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (not (-moz-pref("userChrome.icon.panel_full"))) {
   :root {
     /* Global */
     --arrowpanel-menuicon-paddingx2: calc(var(--arrowpanel-menuicon-padding) * 2);
@@ -293,39 +293,39 @@
     --arrowpanel-menuitemblank-padding: calc(var(--arrowpanel-menuitem-padding-block) + 1px);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #downloadsHistory .button-text,
   .subviewbutton > .toolbarbutton-text {
     padding-inline-start: var(--arrowpanel-menuicon-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .toolbaritem-combined-buttons:not(.unified-extensions-item)
     > .subviewbutton:not(.subviewbutton-iconic)
     > .toolbarbutton-text {
     padding-inline-start: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenu_bookmarksMenu .subviewbutton[disabled="true"],
   #appMenu_historyMenu .subviewbutton[disabled="true"] {
     margin-inline-start: 0 !important;
     padding-inline-start: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenu_bookmarksMenu .subviewbutton[disabled="true"] .toolbarbutton-text,
   #appMenu_historyMenu .subviewbutton[disabled="true"] .toolbarbutton-text {
     padding-inline-start: var(--arrowpanel-menublank-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-proton-update-banner .toolbarbutton-text {
     margin-inline-start: 0 !important;
     padding-inline-start: 0 !important; /* FF v107 */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-multiView .subviewbutton::before,
   #appMenu-proton-update-banner::before {
     display: inline-flex;
@@ -335,13 +335,13 @@
     height: 16px;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-proton-update-banner {
     margin-bottom: 2px !important;
     padding-inline-start: var(--arrowpanel-menuitem-padding-inline) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-fxa-status2,
   #appMenu-zoom-controls2,
   #appMenu-zoom-controls {
@@ -350,13 +350,13 @@
     padding-bottom: var(--arrowpanel-menuimageblank-padding-block) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-zoom-controls2::before,
   #appMenu-zoom-controls::before {
     margin-inline-end: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-zoomReduce-button2,
   #appMenu-zoomReset-button2,
   #appMenu-zoomEnlarge-button2,
@@ -364,12 +364,12 @@
     --arrowpanel-menuitem-padding-block: 0px;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .subviewbutton[type="checkbox"]:not([checked="true"], #allTabsMenu_sortTabsButton) > .toolbarbutton-text {
     margin-left: 16px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-multiView .subviewbutton::before,
   #appMenu-proton-update-banner::before,
   #downloadsHistory .button-icon,
@@ -379,25 +379,25 @@
     -moz-context-properties: fill, fill-opacity, stroke !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-zoomReduce-button2 > .toolbarbutton-icon,
   #appMenu-zoomEnlarge-button2 > .toolbarbutton-icon {
     stroke: var(--zoom-controls-bgcolor, var(--button-bgcolor, ButtonFace)) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-zoomReduce-button2:not([disabled], [open], :active):is(:hover) > .toolbarbutton-icon,
   #appMenu-zoomEnlarge-button2:not([disabled], [open], :active):is(:hover) > .toolbarbutton-icon {
     stroke: var(--button-hover-bgcolor) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .subviewbutton[disabled="true"] > image {
     /* Ghost icons when disabled */
     opacity: 0.4;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-proton-addon-banners > .addon-banner-item > .toolbarbutton-icon {
     display: inline-flex !important;
     display: -moz-inline-box !important;
@@ -406,30 +406,30 @@
     -moz-box-ordinal-group: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-addon-banners > .addon-banner-item > .toolbarbutton-icon {
     display: inline-flex !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-update-banner::before,
   #appMenu-proton-update-banner::before {
     content: url("../icons/whatsnew.svg");
     margin-inline-end: 0px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-fxa-status2::before {
     /* Don't exist img tag */
     content: url("chrome://browser/skin/fxa/avatar-empty.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-fxa-status2:is([fxastatus="signedin"], [fxastatus="unverified"], [fxastatus="login-failed"])::before {
     display: none;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-fxa-status2:is([fxastatus="signedin"], [fxastatus="unverified"], [fxastatus="login-failed"])
     #appMenu-fxa-label2::before {
     /* url("https://profile.accounts.firefox.com/v1/avatar/a") */
@@ -439,18 +439,18 @@
     background-image: var(--avatar-image-url) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #new-tab-button {
     list-style-image: var(--uc-new-tab-icon) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_full"),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_photon") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_full")),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_photon")) {
   #appMenu-new-tab-button2 {
     list-style-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_photon") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_photon")) {
   #appMenu-save-file-button2,
   #appMenu-find-button2,
   #appMenu-more-button2 {
@@ -462,7 +462,7 @@
     padding-inline-start: var(--arrowpanel-menuimageblank-padding-horizontal) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (not (-moz-bool-pref: "userChrome.icon.panel_photon")) and (not (-moz-bool-pref: "userChrome.icon.panel_full")) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (not (-moz-pref("userChrome.icon.panel_photon"))) and (not (-moz-pref("userChrome.icon.panel_full"))) {
   #appMenu-new-tab-button2,
   #appMenu-passwords-button,
   #appMenu-extensions-themes-button,
@@ -479,33 +479,33 @@
     padding-inline-start: var(--arrowpanel-menuimageblank-padding-horizontal) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-new-window-button2 {
     list-style-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-new-private-window-button2 {
     list-style-image: url("chrome://browser/skin/privateBrowsing.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-bookmarks-button {
     list-style-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-history-button {
     list-style-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-downloads-button {
     list-style-image: url("chrome://browser/skin/downloads/downloads.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_full"),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_photon") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_full")),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_photon")) {
   #appMenu-passwords-button {
     list-style-image: url("chrome://browser/skin/login.svg");
   }
@@ -513,12 +513,12 @@
     list-style-image: url("chrome://mozapps/skin/extensions/extension.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-print-button2 {
     list-style-image: url("chrome://global/skin/icons/print.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_full")) {
   #appMenu-save-file-button2 {
     list-style-image: url("../icons/toolbarButton-download.svg");
   }
@@ -533,73 +533,73 @@
     content: url("../icons/screenshot.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #save-page-button {
     list-style-image: url("../icons/toolbarButton-download.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #open-file-button {
     list-style-image: url("../icons/toolbarButton-upload.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #cut-button {
     list-style-image: url("../icons/edit-cut.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #copy-button {
     list-style-image: url("../icons/edit-copy.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #paste-button {
     list-style-image: url("../icons/edit-paste.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #characterencoding-button {
     list-style-image: url("../icons/characterEncoding.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #screenshot-button {
     list-style-image: url("../icons/screenshot-1.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #email-link-button {
     list-style-image: url("../icons/mail.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panic-button {
     list-style-image: url("../icons/forget.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #profiler-button-button > .toolbarbutton-icon {
     list-style-image: url("../icons/performance.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #developer-button {
     list-style-image: url("../icons/wrench-filled.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-settings-button {
     list-style-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_full")) {
   #appMenu-more-button2 {
     list-style-image: url("../icons/ion.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_full"),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.panel_photon") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_full")),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.panel_photon")) {
   #appMenu-help-button2 {
     list-style-image: url("chrome://global/skin/icons/help.svg");
   }
@@ -607,14 +607,14 @@
     list-style-image: url("../icons/quit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-connect-device-button .toolbarbutton-icon,
   #PanelUI-fxa-menu-account-signout-button .toolbarbutton-icon {
     width: 16px !important;
     height: 16px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #fxa-manage-account-button::before {
     content: "";
     display: inline-flex;
@@ -627,19 +627,19 @@
     margin-inline-end: var(--arrowpanel-menuicon-padding);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.account_image_to_right") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.account_image_to_right")) {
   #fxa-manage-account-button::before {
     order: 2 !important;
     -moz-box-ordinal-group: 2 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "userChrome.icon.account_label_to_right") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("userChrome.icon.account_label_to_right")) {
   #fxa-menu-header-title,
   #fxa-menu-header-description {
     text-align: right;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .syncNowBtn {
     visibility: visible !important;
     order: -1 !important;
@@ -647,39 +647,39 @@
     margin-inline-end: var(--arrowpanel-menuicon-padding);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-setup-sync-button {
     list-style-image: url("chrome://browser/skin/sync.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (prefers-reduced-motion: reduce) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (prefers-reduced-motion: reduce) {
   #PanelUI-fxa-menu-syncnow-button[syncstatus="active"] > .toolbarbutton-icon,
   #PanelUI-remotetabs-syncnow[syncstatus="active"] > .toolbarbutton-icon,
   .syncNowBtn[syncstatus="active"] {
     list-style-image: url("chrome://browser/skin/tabbrowser/hourglass.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-connect-device-button {
     list-style-image: url("../icons/add-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-sendtab-button {
     list-style-image: url("../icons/send-to-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-sync-prefs-button {
     list-style-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu-account-signout-button {
     list-style-image: url("../icons/sign-out.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-remotetabs-view-managedevices::before {
     /* Box */
     content: "";
@@ -696,7 +696,7 @@
     background-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .PanelUI-remotetabs-notabsforclient-label {
     margin-inline-start: calc(
       var(--arrowpanel-menuicon-padding) + var(--arrowpanel-menuitem-padding-inline)
@@ -704,7 +704,7 @@
     padding-inline-start: var(--arrowpanel-menublank-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu::before {
     content: "";
     display: flex;
@@ -714,273 +714,273 @@
     padding: 0;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-signedin-panel[hidden="true"] + #PanelUI-fxa-cta-menu #PanelUI-products-separator {
     display: none;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-fxa-menu > :first-child {
     order: -1;
     -moz-box-ordinal-group: 0;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-sign-out-separator {
     display: none;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .pageAction-sendToDevice-device.subviewbutton.sync-menuitem.sendtab-target[clientType=""],
   .sendToDevice-device.subviewbutton.sync-menuitem.sendtab-target[clientType=""] {
     list-style-image: url("../icons/send-to-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .pageAction-sendToDevice-device.subviewbutton.sync-menuitem.sendtab-target:not([clientType]),
   .sendToDevice-device.subviewbutton.sync-menuitem.sendtab-target:not([clientType]) {
     list-style-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenuBookmarkThisPage {
     list-style-image: url("chrome://browser/skin/bookmark-hollow.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   panelMenuBookmarkThisPage[starred] {
     list-style-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenu_searchBookmarks {
     list-style-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenu_viewBookmarksToolbar {
     list-style-image: url("../icons/bookmarks-toolbar-alt.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #panelMenu_showAllBookmarks {
     list-style-image: url("chrome://browser/skin/bookmark-star-on-tray.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuRecentlyClosedTabs {
     list-style-image: var(--uc-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuRecentlyClosedWindows {
     list-style-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuSearchHistory {
     list-style-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuRestoreSession,
   #appMenu-restoreSession {
     list-style-image: url("../icons/restore-session.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuClearRecentHistory {
     list-style-image: url("../icons/forget.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #PanelUI-historyMore {
     list-style-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-library-recentlyClosedTabs {
     list-style-image: url("../icons/movetowindow-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-library-recentlyClosedWindows {
     list-style-image: url("../icons/restore-session.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-moreTools-button {
     list-style-image: url("chrome://browser/skin/customize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-child(1),
   #PanelUI-developer-tools-view .subviewbutton:nth-child(1) {
     list-style-image: url("../icons/developer.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-child(2),
   #PanelUI-developer-tools-view .subviewbutton:nth-child(2) {
     list-style-image: url("../icons/performance.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-child(3),
   #PanelUI-developer-tools-view .subviewbutton:nth-child(3) {
     list-style-image: url("../icons/bug.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-child(4),
   #PanelUI-developer-tools-view .subviewbutton:nth-child(4) {
     list-style-image: url("../icons/window-dev-tools.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-child(5),
   #PanelUI-developer-tools-view .subviewbutton:nth-child(5) {
     list-style-image: url("../icons/command-frames.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-last-child(5),
   #PanelUI-developer-tools-view .subviewbutton:nth-last-child(5) {
     list-style-image: url("../icons/command-console.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-last-child(4),
   #PanelUI-developer-tools-view .subviewbutton:nth-last-child(4) {
     list-style-image: url("../icons/command-responsivemode.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-last-child(3),
   #PanelUI-developer-tools-view .subviewbutton:nth-last-child(3) {
     list-style-image: url("../icons/command-eyedropper.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-last-child(2),
   #PanelUI-developer-tools-view .subviewbutton:nth-last-child(2) {
     list-style-image: url("../icons/document-search.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:nth-last-child(1),
   #PanelUI-developer-tools-view .subviewbutton:nth-last-child(1) {
     list-style-image: url("chrome://mozapps/skin/extensions/extension.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appmenu-developer-tools-view .subviewbutton:last-child {
     margin-bottom: 6px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_menu_openHelp {
     list-style-image: url("chrome://global/skin/icons/help.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_feedbackPage {
     list-style-image: url("../icons/send.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_helpSafeMode {
     list-style-image: url("chrome://devtools/skin/images/debugging-workers.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_troubleShooting {
     list-style-image: url("chrome://global/skin/icons/more.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-report-broken-site-button,
   #appMenu_help_reportSiteIssue {
     list-style-image: url("chrome://global/skin/icons/lightbulb.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_menu_HelpPopup_reportPhishingtoolmenu {
     list-style-image: url("chrome://global/skin/icons/warning.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_helpSwitchDevice {
     list-style-image: url("../icons/add-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu_aboutName {
     list-style-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-library-bookmarks-button {
     list-style-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-library-history-button {
     list-style-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-library-downloads-button {
     list-style-image: url("chrome://browser/skin/downloads/downloads.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #downloadsHistory {
     list-style-image: url("chrome://browser/skin/downloads/downloads.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #downloadsHistory .box-inherit.button-box {
     display: inline-flex !important;
     display: -moz-inline-box !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #overflowMenu-customize-button {
     list-style-image: url("chrome://browser/skin/customize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-undoCloseTab {
     list-style-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-searchTabs {
     list-style-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-closeDuplicateTabs {
     list-style-image: var(--uc-tab-close-duplicate-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-containerTabsButton {
     list-style-image: url("../icons/container-openin-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-hiddenTabsButton {
     list-style-image: url("../icons/eye-hide.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu-containerTabsView .subviewbutton:last-child {
     list-style-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #BMB_viewBookmarksSidebar {
     --menuitem-image: var(--uc-sidebar-icon);
   }
@@ -988,23 +988,23 @@
     --menuitem-image: url("chrome://global/skin/icons/close.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #BMB_searchBookmarks {
     --menuitem-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #BMB_bookmarksShowAllTop,
   #BMB_bookmarksShowAll {
     --menuitem-image: url("chrome://browser/skin/bookmark-star-on-tray.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #BMB_bookmarksToolbar {
     --menuitem-image: url("../icons/bookmarks-toolbar-alt.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   #BMB_bookmarksShowAllTop {
     list-style-image: url("chrome://browser/skin/bookmark-star-on-tray.svg") !important;
   }
@@ -1013,7 +1013,7 @@
     display: -moz-box !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #BMB_viewBookmarksToolbar[data-l10n-args='{"isVisible":true}'] {
     --menuitem-image: url("../icons/eye-hide.svg");
   }
@@ -1021,7 +1021,7 @@
     --menuitem-image: url("../icons/eye-show.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #protections-popup-settings-button > .protections-popup-settings-icon,
   #protections-popup-show-report-button > .protections-popup-show-report-icon {
     -moz-context-properties: fill, fill-opacity, stroke;
@@ -1029,35 +1029,35 @@
     margin-inline-end: 1em;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #protections-popup-settings-button > .protections-popup-settings-icon,
   #protections-popup-multiView .panel-subview-footer-button {
     list-style-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #protections-popup-show-report-button > .protections-popup-show-report-icon {
     /* chrome://browser/skin/controlcenter/dashboard.svg */
     list-style-image: url("../icons/dashboard.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #identity-popup-clear-sitedata-button,
   #identity-popup-more-info {
     padding-inline: 5px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #identity-popup-securityView-body {
     margin-inline-start: 32px !important; /* Original: 10px */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #identity-popup-clear-sitedata-button {
     list-style-image: url("../icons/broom.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #identity-popup-more-info.subviewbutton {
     list-style-image: url("chrome://global/skin/icons/info.svg");
   }
@@ -1065,7 +1065,7 @@
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #sidebar-switcher-bookmarks.subviewbutton {
     list-style-image: url("chrome://browser/skin/bookmark.svg");
   }
@@ -1073,7 +1073,7 @@
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #sidebar-switcher-history.subviewbutton {
     list-style-image: url("chrome://browser/skin/history.svg");
   }
@@ -1081,7 +1081,7 @@
     --menuitem-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #sidebar-switcher-tabs.subviewbutton {
     list-style-image: url("../icons/synced-tabs.svg");
   }
@@ -1089,7 +1089,7 @@
     --menuitem-image: url("../icons/synced-tabs.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #sidebar-reverse-position.subviewbutton {
     list-style-image: var(--uc-sidebar-icon-reverse);
   }
@@ -1097,7 +1097,7 @@
     --menuitem-image: var(--uc-sidebar-icon-reverse);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #sidebarMenu-popup > *.subviewbutton[data-l10n-id="sidebar-menu-close"] {
     list-style-image: url("chrome://global/skin/icons/close.svg");
   }
@@ -1105,12 +1105,12 @@
     --menuitem-image: url("chrome://global/skin/icons/close.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #unified-extensions-manage-extensions {
     list-style-image: url("chrome://mozapps/skin/extensions/extension.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   .sync-engine-tabs .checkbox-icon,
   .sync-engine-tabs.sync-engine-image,
   #sidebar-box[sidebarcommand="viewTabsSidebar"] > #sidebar-header > #sidebar-switcher-target > #sidebar-icon,
@@ -1118,12 +1118,12 @@
     list-style-image: url("../icons/synced-tabs.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #allTabsMenu_sortTabsButton {
     list-style-image: url("../icons/text-sort-ascending.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]),
   menupopup menu:not([type="checkbox"][checked="true"], [type="radio"]),
   menupopup menuitem:not([type="checkbox"][checked="true"], [type="radio"]) > .menu-iconic-left > .menu-iconic-icon,
@@ -1211,8 +1211,8 @@
   /* Windows 7, 8 */
   /* Linux */
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "widget.macos.native-context-menus"),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "widget.gtk.native-context-menus") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("widget.macos.native-context-menus")),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("widget.gtk.native-context-menus")) {
   :not(menu, #ContentSelectDropdown)
     > menupopup:not(.in-menulist)
     > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"]),
@@ -1222,7 +1222,7 @@
     list-style-image: var(--menuitem-image, url("../icons/blank.svg")) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   :root {
     --uc-menu-background-position: left;
     --context-menu-background-padding-default: 5px;
@@ -1232,7 +1232,7 @@
     --uc-menu-background-position: right;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   :not(menu, #ContentSelectDropdown, #context-navigation)
     > menupopup:not(.in-menulist)
     > menuitem:not(.menuitem-iconic),
@@ -1289,7 +1289,7 @@
     padding-inline-start: var(--context-menu-background-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   #sidebarMenu-popup:is(menupopup):not(panel) {
     --context-menu-background-padding: var(--context-menu-background-padding-default);
     padding-inline-start: 0 !important;
@@ -1301,7 +1301,7 @@
     margin-inline-start: var(--arrowpanel-menuitem-margin-inline) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menubar") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menubar")) {
   #main-menubar > menu {
     background-position: var(--uc-menu-background-position) var(--context-menu-background-padding-default) center !important;
     padding-inline-start: calc(16px + var(--context-menu-background-padding-default)) !important;
@@ -1316,13 +1316,13 @@
     --menuitem-image: none; /* Prevent Image Inheritance */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menubar") and (not (-moz-bool-pref: "userChrome.padding.global_menubar")) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menubar")) and (not (-moz-pref("userChrome.padding.global_menubar"))) {
   #main-menubar > menu {
     padding-block: 2px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) and (-moz-platform: windows),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) and (-moz-platform: windows) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-platform: windows) and (-moz-platform: windows),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) and (-moz-platform: windows) {
   :root {
     --context-menu-background-padding: 1em;
     --context-menu-text-padding-default: 24px;
@@ -1385,8 +1385,8 @@
     padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) and (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available),
-  (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) and (-moz-bool-pref: "userChrome.theme.non_native_menu") and (-moz-gtk-csd-available) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-platform: windows) and (-moz-pref("userChrome.theme.non_native_menu")) and (-moz-gtk-csd-available),
+  (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) and (-moz-pref("userChrome.theme.non_native_menu")) and (-moz-gtk-csd-available) {
   :root {
     --context-menu-background-padding: 1em;
     --context-menu-text-padding-default: 24px;
@@ -1449,7 +1449,7 @@
     padding-inline: 0 !important; /* Original: padding: var(--panel-padding); --panel-padding-block: 4px; */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-platform: windows) {
   :root {
     --bookmark-menu-icon-text-padding: calc(
       var(--context-menu-text-padding) + var(--arrowpanel-menuitem-padding-inline)
@@ -1459,7 +1459,7 @@
     );
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) {
   :root {
     --context-menu-background-padding-default: 6px;
     --context-menu-text-padding: 21px;
@@ -1468,7 +1468,7 @@
     padding-inline-start: 3px;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   :root {
     --context-menu-background-padding-default: 10px;
     --context-menu-mac-padding: 21px;
@@ -1495,7 +1495,7 @@
   /* Global Menu */
   /* Exeptions */
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") and (-moz-bool-pref: "userChrome.icon.global_menu.mac") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) and (-moz-pref("userChrome.icon.global_menu.mac")) {
   menupopup:is(
       #menu_FilePopup,
       #menu_EditPopup,
@@ -1525,12 +1525,12 @@
     list-style-image: var(--menuitem-image, url("../icons/blank.svg")) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   #unified-extensions-context-menu > menuitem::before {
     padding-inline: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   :not(menu, #ContentSelectDropdown, #context-navigation)
     > menupopup:not(.in-menulist)
     > menuitem:not(.menuitem-iconic, .bookmark-item, .in-menulist, [checked="true"]) {
@@ -1554,19 +1554,19 @@
     padding-left: 8px !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   menupopup menupopup[emptyplacesresult] .menu-text,
   #PersonalToolbar menupopup[emptyplacesresult] .menu-text {
     margin-inline-start: 0 !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   #BMB_bookmarksPopup,
   #PersonalToolbar {
     --context-menu-background-padding: var(--arrowpanel-menuitem-padding-inline);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-platform: windows) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-platform: windows) {
   /* Bookmark Popup - None icon menu */
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menuitem:not(.menuitem-iconic, [disabled="true"]),
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menu:not(.menu-iconic),
@@ -1577,7 +1577,7 @@
     background-position: var(--uc-menu-background-position) var(--bookmark-menu-icon-background-padding) center !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) {
   /* Global Menu */
   menupopup:is(#goPopup, #historyMenuPopup, #bookmarksMenuPopup) .bookmark-item {
     padding-inline-start: var(--context-menu-background-padding) !important;
@@ -1595,7 +1595,7 @@
     padding-inline-start: calc(var(--context-menu-background-padding) + 2px) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) and (-moz-bool-pref: "userChrome.theme.non_native_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) and (-moz-pref("userChrome.theme.non_native_menu")) {
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menuitem:not(.menuitem-iconic, [disabled="true"]),
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menu:not(.menu-iconic),
   #PersonalToolbar menupopup[placespopup="true"] menuitem:not(.menuitem-iconic, [disabled="true"]),
@@ -1603,7 +1603,7 @@
     margin-inline: var(--arrowpanel-menuitem-margin-inline) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-gtk-csd-available) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-gtk-csd-available) {
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menuitem:not(.menuitem-iconic, [disabled="true"]) .menu-text,
   menupopup:is(#BMB_bookmarksPopup)[placespopup="true"] menu:not(.menu-iconic) .menu-text,
   #PersonalToolbar menupopup[placespopup="true"] menuitem:not(.menuitem-iconic, [disabled="true"]) .menu-text,
@@ -1611,7 +1611,7 @@
     margin-inline-start: var(--context-menu-text-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   /* Bookmark Popup - As Arrow Panel */
   #PersonalToolbar menupopup menuitem,
   #PersonalToolbar menupopup menu {
@@ -1633,7 +1633,7 @@
     padding-inline-start: var(--context-menu-mac-padding) !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   /** Context Menu - Icons ******************************************************/ /*= tabContextMenu ===========================================================*/
   #context_openANewTab,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_newTab,
@@ -1747,13 +1747,13 @@
   /*= full-page-translations-panel-settings-menupopup ==========================*/
   /*= select-translations-panel-settings-menupopup =============================*/
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context_shareTabURL,
   menuitem.share-tab-url-item {
     --menuitem-image: url("../icons/share.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context_reopenInContainer,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_reopenInContainer,
   #tabcenter-reborn_ariasuni-menuitem-_contextMenuOpenInContextualTab,
@@ -1762,7 +1762,7 @@
     --menuitem-image: url("../icons/container-openin-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context_selectAllTabs,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_selectAllTabs,
   #treestyletab_piro_sakura_ne_jp-menuitem-_noContextTab\:context_selectAllTabs,
@@ -1770,7 +1770,7 @@
     --menuitem-image: var(--uc-tab-multiple-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context_closeTab,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_closeTab,
   #treestyletab_piro_sakura_ne_jp-menuitem-_grouped\:closeTree,
@@ -1779,12 +1779,12 @@
     --menuitem-image: url("chrome://global/skin/icons/close.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context_closeDuplicateTabs {
     --menuitem-image: var(--uc-tab-close-duplicate-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context_closeTabOptions,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_closeMultipleTabs,
   #tabcenter-reborn_ariasuni-menuitem-_contextMenuCloseTabs,
@@ -1792,7 +1792,7 @@
     --menuitem-image: url("../icons/filter-dismiss.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context_undoCloseTab,
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_undoCloseTab,
   #treestyletab_piro_sakura_ne_jp-menuitem-_noContextTab\:context_undoCloseTab,
@@ -1801,116 +1801,116 @@
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #new-tab-button-popup > menuitem[command="Browser:NewUserContextTab"],
   .new-tab-popup > menuitem[command="Browser:NewUserContextTab"] {
     --menuitem-image: url("../icons/container-openin-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #new-tab-button-popup > menuitem[command="Browser:OpenAboutContainers"],
   .new-tab-popup > menuitem[command="Browser:OpenAboutContainers"] {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-manageExtension {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-removeExtension {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-reportExtension {
     --menuitem-image: url("../icons/send.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-moveToPanel {
     --menuitem-image: url("../icons/pin-tab.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-autohide-downloads-button {
     /* checkbox */
     --menuitem-image: url("../icons/eye-tracking-off.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-removeFromToolbar {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-always-open-downloads-panel {
     /* checkbox */
     --menuitem-image: url("../icons/drawer-arrow-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-openANewTab {
     --menuitem-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-reloadSelectedTab,
   #toolbar-context-reloadSelectedTabs {
     --menuitem-image: url("../icons/reload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-bookmarkSelectedTab,
   #toolbar-context-bookmarkSelectedTabs {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-selectAllTabs {
     --menuitem-image: var(--uc-tab-multiple-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-undoCloseTab {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toggle_toolbar-menubar {
     /* checkbox */
     --menuitem-image: url("../icons/calendar-agenda.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toggle_PersonalToolbar {
     /* Also placeContext */
     --menuitem-image: url("../icons/bookmarks-toolbar-alt.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   menuitem.viewCustomizeToolbar {
     --menuitem-image: url("chrome://browser/skin/customize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .fullscreen-context-autohide {
     /* checkbox */
     --menuitem-image: url("../icons/eye-tracking-off.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #toolbar-context-menu > menuitem[data-l10n-id="full-screen-exit"] {
     --menuitem-image: url("chrome://browser/skin/fullscreen-exit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-platform: windows) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-platform: windows) {
   #context_openANewTab.tabmix-newtab-menu-icon .menu-iconic-left {
     display: none;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #tm-duplicateinWin {
     --menuitem-image: url("../icons/tab-desktop-multiple-bottom.svg");
   }
@@ -1918,462 +1918,462 @@
     --menuitem-image: url("../icons/merge.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-renameTab {
     --menuitem-image: url("chrome://global/skin/icons/edit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-copyTabUrl {
     --menuitem-image: url("../icons/link.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-autoreloadTab_menu {
     --menuitem-image: url("../icons/timer10.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context_reloadTabOptions {
     --menuitem-image: url("../icons/reload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context_reloadTabOptions {
     --menuitem-image: url("../icons/filter-reload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (not (-moz-bool-pref: "userChrome.icon.menu.full")) {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (not (-moz-pref("userChrome.icon.menu.full"))) {
   #context_reloadTabOptions + #context_reloadTab {
     --menuitem-image: url("../icons/blank.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-docShell {
     --menuitem-image: url("chrome://browser/skin/permissions.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-freezeTab {
     --menuitem-image: url("../icons/weather-snowflake.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-protectTab {
     --menuitem-image: url("../icons/shield-task.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #tm-lockTab {
     --menuitem-image: url("../icons/lock-closed.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context_bookmarkAllTabs {
     --menuitem-image: url("../icons/bookmark-multiple.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewsource-goToLine {
     --menuitem-image: url("../icons/text-number-format.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewsource-wrapLongLines {
     /* checkbox */
     --menuitem-image: url("../icons/arrow-sort-down-lines.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewsource-highlightSyntax {
     /* checkbox */
     --menuitem-image: url("../icons/highlight.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-no-suggestions {
     --menuitem-image: url("../icons/text-proofing-tools.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-add-to-dictionary,
   #spell-add-dictionaries {
     --menuitem-image: url("../icons/book-add.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-undo-add-to-dictionary {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openlinkincurrent {
     --menuitem-image: url("../icons/link-square.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openlinkincontainertab,
   #context-openlinkintab {
     --menuitem-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openlinkinusercontext-menu {
     --menuitem-image: url("../icons/container-openin-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openlink {
     --menuitem-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openlinkprivate {
     --menuitem-image: url("chrome://browser/skin/privateBrowsing.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-bookmarklink {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-savelink {
     --menuitem-image: url("../icons/toolbarButton-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-savelinktopocket {
     --menuitem-image: url("../icons/pocket-outline.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copyemail {
     --menuitem-image: url("../icons/mail.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copyphone {
     --menuitem-image: url("../icons/device-phone.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copylink {
     --menuitem-image: url("../icons/link.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-stripOnShareLink {
     --menuitem-image: url("../icons/link-no-tracking.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-sendlinktodevice {
     --menuitem-image: url("../icons/send-to-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-play {
     --menuitem-image: url("chrome://global/skin/media/play-fill.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-pause {
     --menuitem-image: url("chrome://global/skin/media/pause-fill.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-mute {
     --menuitem-image: url("chrome://global/skin/media/audio-muted.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-unmute {
     --menuitem-image: url("chrome://global/skin/media/audio.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-playbackrate {
     --menuitem-image: url("../icons/time-picker.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-loop {
     /* checkbox */
     --menuitem-image: url("../icons/arrow-repeat-all.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-leave-dom-fullscreen {
     --menuitem-image: url("chrome://global/skin/media/fullscreenExitButton.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-video-fullscreen {
     --menuitem-image: url("chrome://global/skin/media/fullscreenEnterButton.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-hidecontrols {
     --menuitem-image: url("../icons/eye-hide.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-showcontrols {
     --menuitem-image: url("../icons/eye-show.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewvideo {
     --menuitem-image: url("../icons/video.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-video-pictureinpicture {
     /* checkbox */
     --menuitem-image: url("chrome://global/skin/media/picture-in-picture-open.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-reloadimage {
     --menuitem-image: url("../icons/image-arrow-counterclockwise.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewimage {
     --menuitem-image: url("../icons/image-add.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-saveimage {
     --menuitem-image: url("../icons/image.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-video-saveimage {
     --menuitem-image: url("../icons/video-snapshot.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-savevideo {
     --menuitem-image: url("../icons/video.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-saveaudio {
     --menuitem-image: url("chrome://global/skin/media/audio.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copyimage-contents {
     --menuitem-image: url("../icons/image-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copyimage,
   #context-copyvideourl,
   #context-copyaudiourl {
     --menuitem-image: url("../icons/link.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-sendimage,
   #context-sendvideo,
   #context-sendaudio {
     --menuitem-image: url("../icons/mail.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewimageinfo {
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewimagedesc {
     --menuitem-image: url("../icons/image-alt-text.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-setDesktopBackground {
     --menuitem-image: url("../icons/resize-image.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-ctp-play {
     --menuitem-image: url("chrome://global/skin/icons/plugin.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-ctp-hide {
     --menuitem-image: url("chrome://global/skin/icons/plugin-blocked.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-savepage {
     --menuitem-image: url("../icons/toolbarButton-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-pocket {
     --menuitem-image: url("../icons/pocket-outline.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-sendpagetodevice {
     --menuitem-image: url("../icons/send-to-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #fill-login {
     --menuitem-image: url("../icons/password.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #fill-login-generated-password {
     --menuitem-image: url("chrome://browser/skin/login.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #use-relay-mask {
     --menuitem-image: url("../icons/relay-logo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #manage-saved-logins {
     --menuitem-image: url("../icons/key-multiple.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-undo,
   #context-pdfjs-undo {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #context-redo,
   #context-pdfjs-redo {
     --menuitem-image: url("../icons/redo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-cut,
   #context-pdfjs-cut {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-copy,
   #context-pdfjs-copy {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-paste,
   #context-pdfjs-paste {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-delete,
   #context-pdfjs-delete {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-selectall,
   #context-pdfjs-selectall {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-pdfjs-highlight-selection {
     --menuitem-image: url("../icons/toolbarButton-editorHighlight.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-reveal-password {
     --menuitem-image: url("../icons/eye-show.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-print-selection {
     --menuitem-image: url("chrome://global/skin/icons/print.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-take-screenshot {
     --menuitem-image: url("../icons/screenshot-1.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-keywordfield {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-searchselect,
   #context-searchselect-private {
     --menuitem-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-translate-selection {
     --menuitem-image: url("../icons/translations.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #frame {
     --menuitem-image: url("../icons/command-frames.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-check-enabled {
     /* checkbox */
     --menuitem-image: url("../icons/text-proofing-tools.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-add-dictionaries-main {
     --menuitem-image: url("../icons/book-add.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #spell-dictionaries {
     --menuitem-image: url("../icons/book.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-bidi-text-direction-toggle {
     --menuitem-image: url("../icons/text-direction-horizontal-ltr.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-bidi-page-direction-toggle {
     --menuitem-image: url("../icons/document-landscape-split-hint.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewpartialsource-selection,
   #context-viewsource {
     --menuitem-image: url("../icons/document-search.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-inspect-a11y {
     --menuitem-image: url("../icons/tool-accessibility.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-inspect {
     --menuitem-image: url("../icons/command-pick.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-media-eme-learnmore {
     /* iconic */
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "layout.css.osx-font-smoothing.enabled") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("layout.css.osx-font-smoothing.enabled")) {
   #context-back {
     --menuitem-image: url("chrome://browser/skin/back.svg");
   }
@@ -2390,159 +2390,159 @@
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-showonlythisframe {
     --menuitem-image: url("../icons/eye-show.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openframeintab {
     --menuitem-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-openframe {
     --menuitem-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-reloadframe {
     --menuitem-image: url("../icons/reload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-bookmarkframe {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-saveframe {
     --menuitem-image: url("../icons/toolbarButton-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-printframe {
     --menuitem-image: url("chrome://global/skin/icons/print.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-take-frame-screenshot {
     --menuitem-image: url("../icons/screenshot-1.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewframesource {
     --menuitem-image: url("../icons/document-search.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #context-viewframeinfo {
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-autoreload_menu {
     --menuitem-image: url("../icons/timer10.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-linkWithhistory {
     --menuitem-image: var(--uc-new-tab-skip-forward-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-openAllLinks {
     --menuitem-image: var(--uc-new-tab-multiple-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-openinverselink {
     --menuitem-image: var(--uc-new-tab-forward-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-content-closetab {
     --menuitem-image: url("../icons/dismiss-filled.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-duplicateTabContext {
     --menuitem-image: var(--uc-tab-copy-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-duplicateinWinContext {
     --menuitem-image: url("../icons/tab-desktop-multiple-bottom.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-detachTabContext {
     --menuitem-image: url("../icons/convert-range.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-mergeWindows {
     --menuitem-image: url("../icons/merge.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-content-freezeTab {
     --menuitem-image: url("../icons/weather-snowflake.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-content-protectTab {
     --menuitem-image: url("../icons/shield-task.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-content-lockTab {
     --menuitem-image: url("../icons/lock-closed.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #tm-content-undoCloseTab {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadPauseMenuItem {
     --menuitem-image: url("chrome://global/skin/media/pause-fill.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadResumeMenuItem {
     --menuitem-image: url("chrome://global/skin/media/play-fill.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadUnblockMenuItem {
     --menuitem-image: url("../icons/checkmark-circle.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadUseSystemDefaultMenuItem {
     --menuitem-image: url("../icons/toolbarButton-upload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadAlwaysUseSystemDefaultMenuItem {
     /* checkbox */
     --menuitem-image: url("../icons/folder-globe.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadAlwaysOpenSimilarFilesMenuItem {
     /* checkbox */
     --menuitem-image: url("../icons/fluid.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadShowMenuItem {
     --menuitem-image: var(--uc-folder-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #downloadsContextMenu > menuitem.downloadOpenReferrerMenuItem,
   #downloadsContextMenu > menuitem[command="downloadsCmd_openReferrer"] {
     --menuitem-image: url("../icons/link-square.svg");
@@ -2552,63 +2552,63 @@
     --menuitem-image: url("../icons/link.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadDeleteFileMenuItem {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .downloadRemoveFromHistoryMenuItem {
     --menuitem-image: url("../icons/eraser.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #downloadsContextMenu > menuitem[command="downloadsCmd_clearList"],
   #downloadsContextMenu > menuitem[command="downloadsCmd_clearDownloads"] {
     --menuitem-image: url("../icons/broom.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_open {
     --menuitem-image: url("../icons/link-square.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_openBookmarkContainer\:tabs,
   #placesContext_openBookmarkLinks\:tabs {
     --menuitem-image: url("../icons/movetowindow-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_open\:newtab,
   #placesContext_openContainer\:tabs,
   #placesContext_openLinks\:tabs {
     --menuitem-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_open\:newcontainertab {
     --menuitem-image: url("../icons/container-openin-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_open\:newwindow {
     --menuitem-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_open\:newprivatewindow {
     --menuitem-image: url("chrome://browser/skin/privateBrowsing.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_show_bookmark\:info,
   #placesContext_show\:info,
   #placesContext_show_folder\:info {
     --menuitem-image: url("chrome://global/skin/icons/edit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_deleteBookmark,
   #placesContext_deleteFolder,
   #placesContext_delete,
@@ -2616,127 +2616,127 @@
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_deleteHost {
     --menuitem-image: url("../icons/eye-hide.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_sortBy\:name {
     --menuitem-image: url("../icons/text-sort-ascending.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_cut {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_copy {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_paste_group {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_new\:bookmark {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_showInFolder,
   #placesContext_new\:folder {
     --menuitem-image: var(--uc-folder-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_new\:separator {
     --menuitem-image: url("../icons/vertical-line.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_paste {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_createBookmark {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #show-other-bookmarks_PersonalToolbar {
     /* checkbox */
     --menuitem-image: url("../icons/star-line-horizontal.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #placesContext_showAllBookmarks {
     --menuitem-image: url("chrome://browser/skin/bookmark-star-on-tray.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .openintabs-menuitem {
     --menuitem-image: url("../icons/movetowindow-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #doNotDisturbMenuItem {
     --menuitem-image: url(chrome://global/skin/media/pause-fill.svg);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #disableForOriginMenuItem {
     --menuitem-image: url("chrome://global/skin/icons/blocked.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #openSettingsMenuItem {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #blockedPopupAllowSite {
     --menuitem-image: url("chrome://global/skin/icons/check.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #blockedPopupOptions > menuitem[oncommand="gPopupBlockerObserver.editPopupSettings();"] {
     --menuitem-image: url("chrome://global/skin/icons/edit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #blockedPopupDontShowMessage {
     /* checkbox */
     --menuitem-image: url("chrome://global/skin/icons/blocked.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   menuitem[data-l10n-id="popup-show-popup-menuitem"] {
     /* checkbox */
     --menuitem-image: url("../icons/eye-show.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #autohide-context > menuitem[data-l10n-id="full-screen-autohide"] {
     /* checkbox */
     --menuitem-image: url("../icons/eye-tracking-off.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #autohide-context > menuitem[data-l10n-id="full-screen-exit"] {
     --menuitem-image: url("chrome://browser/skin/fullscreen-exit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #pictureInPictureToggleContextMenu > menuitem[oncommand="PictureInPicture.hideToggle();"] {
     --menuitem-image: url("../icons/eye-hide.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .pageActionContextMenuItem.extensionPinned.extensionUnpinned.manageExtensionItem {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
@@ -2744,208 +2744,208 @@
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #customizationPanelItemContextMenuUnpin {
     --menuitem-image: url("../icons/unpin-tab.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-removeFromPanel {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-addToToolbar {
     --menuitem-image: url("chrome://devtools/skin/images/dock-bottom.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .customize-context-addToPanel {
     --menuitem-image: url("chrome://browser/skin/menu.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #customizationPanelContextMenu > menuitem[command="cmd_CustomizeToolbars"] {
     --menuitem-image: url("chrome://browser/skin/customize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #downloads-button-autohide-checkbox {
     /* checkbox */
     --menuitem-image: url("../icons/eye-tracking-off.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsOpenSelected {
     --menuitem-image: url("../icons/link-square.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsOpenSelectedInTab {
     --menuitem-image: var(--uc-new-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsOpenSelectedInWindow {
     --menuitem-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsOpenSelectedInPrivateWindow {
     --menuitem-image: url("chrome://browser/skin/privateBrowsing.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsBookmarkSelected {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsCopySelected {
     --menuitem-image: url("../icons/link.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsOpenAllInTabs {
     --menuitem-image: url("../icons/movetowindow-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsManageDevices {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsRefresh {
     --menuitem-image: url("chrome://browser/skin/sync.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_undo"] {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_cut"] {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_copy"] {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_paste"] {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_delete"] {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #SyncedTabsSidebarTabsFilterContext > menuitem[cmd="cmd_selectAll"] {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #syncedTabsRefreshFilter {
     --menuitem-image: url("chrome://browser/skin/sync.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_undo"] {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_redo"] {
     --menuitem-image: url("../icons/redo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_cut"] {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_copy"] {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #strip-on-share {
     --menuitem-image: url("../icons/link-no-tracking.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_paste"] {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #paste-and-go {
     --menuitem-image: url("../icons/edit-paste-go.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_delete"] {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #urlbar-input-container .textbox-contextmenu menuitem[cmd="cmd_selectAll"] {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-undo"] {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-redo"] {
     --menuitem-image: url("../icons/redo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-cut"] {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-copy"] {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-paste"] {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-delete"] {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .textbox-contextmenu > menuitem[data-l10n-id="text-action-select-all"] {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   menuitem.searchbar-paste-and-search {
     --menuitem-image: url("../icons/edit-paste-search.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   menuitem.searchbar-clear-history {
     --menuitem-image: url("../icons/forget.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .sync-menuitem.sendtab-target[clientType="phone"] {
     --menuitem-image: url("../icons/device-phone.svg");
   }
@@ -2968,42 +2968,42 @@
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #treestyletab_piro_sakura_ne_jp-menuitem-_context_sendTabsToDevice\:manage {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-pin-to-toolbar {
     --menuitem-image: url("../icons/pin-tab.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-move-widget-up {
     --menuitem-image: url("chrome://global/skin/icons/arrow-up.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-move-widget-down {
     --menuitem-image: url("chrome://global/skin/icons/arrow-down.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-manage-extension {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-remove-extension {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .unified-extensions-context-menu-report-extension {
     --menuitem-image: url("../icons/send.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .urlbarView-result-menuitem[data-command="dismiss"] {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
@@ -3011,27 +3011,27 @@
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   .manage-languages-menuitem {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #full-page-translations-panel-settings-menupopup > menuitem[data-l10n-id="translations-panel-settings-about2"] {
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #select-translations-panel-open-settings-page-menuitem {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.context_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.context_menu")) {
   #select-translations-panel-about-translations-menuitem {
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menubar") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menubar")) {
   /*= main-menubar =============================================================*/
   #file-menu {
     --menuitem-image: url("../icons/mail-inbox-all.svg");
@@ -3058,7 +3058,7 @@
     --menuitem-image: url("chrome://global/skin/icons/help.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   /** Global Menu ***************************************************************/
   /*= menu_FilePopup ===========================================================*/
   #menu_newNavigatorTab {
@@ -3093,361 +3093,361 @@
   /*= windowPopup ==============================================================*/
   /*= menu_HelpPopup ===========================================================*/
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #menu_closeWindow {
     --menuitem-image: url("../icons/close-window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_savePage {
     --menuitem-image: url("../icons/toolbarButton-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_sendLink {
     --menuitem-image: url("../icons/mail.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   menu.share-tab-url-item {
     --menuitem-image: url("chrome://browser/skin/share.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_print {
     --menuitem-image: url("chrome://global/skin/icons/print.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_importFromAnotherBrowser {
     --menuitem-image: url("chrome://browser/skin/import.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #goOfflineMenuitem {
     /* checkbox */
     --menuitem-image: url("../icons/plug-disconnected.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_FileQuitItem {
     --menuitem-image: url("../icons/quit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_newUserContext menupopup menuitem:last-child {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_undo {
     --menuitem-image: url("../icons/undo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #menu_redo {
     --menuitem-image: url("../icons/redo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_cut {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_copy {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_paste {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_delete {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_selectAll {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_find {
     --menuitem-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) and (-moz-pref("userChrome.icon.menu.full")) {
   #menu_findAgain {
     --menuitem-image: url("../icons/find-again.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_preferences {
     --menuitem-image: url("chrome://global/skin/icons/settings.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #viewToolbarsMenu {
     --menuitem-image: url("../icons/toolbar.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #viewSidebarMenuMenu {
     --menuitem-image: var(--uc-sidebar-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #viewFullZoomMenu {
     --menuitem-image: url("../icons/screenshot.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #pageStyleMenu {
     --menuitem-image: url("../icons/document-css.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #repair-text-encoding {
     --menuitem-image: url("../icons/characterEncoding.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #enterFullScreenItem {
     --menuitem-image: url("chrome://browser/skin/fullscreen.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #exitFullScreenItem {
     --menuitem-image: url("chrome://browser/skin/fullscreen-exit.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #fullScreenItem {
     /* checkbox */
     --menuitem-image: url("chrome://browser/skin/fullscreen.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_readerModeItem {
     --menuitem-image: url("chrome://browser/skin/reader-mode.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_showAllTabs {
     --menuitem-image: var(--uc-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #documentDirection-swap {
     --menuitem-image: url("../icons/text-direction-horizontal-ltr.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_customizeToolbars {
     --menuitem-image: url("chrome://browser/skin/customize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_bookmarksSidebar {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_historySidebar {
     --menuitem-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_tabsSidebar {
     --menuitem-image: url("../icons/synced-tabs.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_zoomEnlarge {
     --menuitem-image: url("chrome://browser/skin/add-circle-fill.svg");
     stroke: transparent !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_zoomReduce {
     --menuitem-image: url("chrome://browser/skin/subtract-circle-fill.svg");
     stroke: transparent !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_zoomReset {
     --menuitem-image: url("../icons/resize.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #toggle_zoom {
     --menuitem-image: url("../icons/screenshot.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_showAllHistory {
     --menuitem-image: url("chrome://browser/skin/history.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #sanitizeItem {
     --menuitem-image: url("../icons/forget.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #sync-tabs-menuitem {
     --menuitem-image: url("chrome://browser/skin/sync.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #historyRestoreLastSession {
     --menuitem-image: url("../icons/restore-session.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #hiddenTabsMenu {
     --menuitem-image: url("../icons/eye-hide.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_searchHistory {
     --menuitem-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #historyUndoMenu {
     --menuitem-image: var(--uc-tab-icon);
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #historyUndoWindowMenu {
     --menuitem-image: url("chrome://browser/skin/window.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #historyUndoPopup .restoreallitem {
     --menuitem-image: url("../icons/movetowindow-16.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #historyUndoWindowPopup .restoreallitem {
     --menuitem-image: url("../icons/restore-session.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #bookmarksShowAll {
     --menuitem-image: url("chrome://browser/skin/bookmark-star-on-tray.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_bookmarkThisPage,
   #menu_bookmarkAllTabs {
     --menuitem-image: url("chrome://browser/skin/bookmark-hollow.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_bookmarkThisPage[data-l10n-id="menu-bookmark-edit"] {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_searchBookmarks {
     --menuitem-image: url("chrome://global/skin/icons/search-glass.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_openDownloads {
     --menuitem-image: url("chrome://browser/skin/downloads/downloads.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_openAddons {
     --menuitem-image: url("chrome://mozapps/skin/extensions/extension.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #sync-setup {
     --menuitem-image: url("chrome://browser/skin/fxa/avatar-empty.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #sync-syncnowitem {
     --menuitem-image: url("chrome://browser/skin/sync.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_openFirefoxView {
     --menuitem-image: url("../icons/firefox-view.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #webDeveloperMenu,
   #browserToolsMenu {
     --menuitem-image: url("../icons/developer.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_pageInfo {
     --menuitem-image: url("../icons/document-endnote.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_devToolbox {
     /* checkbox */
     --menuitem-image: url("../icons/developer.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_taskManager {
     --menuitem-image: url("../icons/performance.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_devtools_remotedebugging {
     --menuitem-image: url("../icons/bug.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_browserToolbox {
     --menuitem-image: url("../icons/window-dev-tools.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_browserContentToolbox {
     --menuitem-image: url("../icons/command-frames.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_browserConsole {
     --menuitem-image: url("../icons/command-console.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_responsiveUI {
     /* checkbox */
     --menuitem-image: url("../icons/command-responsivemode.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_eyedropper {
     /* checkbox */
     --menuitem-image: url("../icons/command-eyedropper.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_pageSource {
     --menuitem-image: url("../icons/document-search.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #extensionsForDevelopers {
     --menuitem-image: url("chrome://mozapps/skin/extensions/extension.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #windowPopup > menuitem[command="minimizeWindow"] {
     --menuitem-image: url("../icons/arrow-between-down.svg");
   }
@@ -3455,57 +3455,57 @@
     --menuitem-image: url("../icons/auto-fit-width.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_openHelp {
     --menuitem-image: url("chrome://global/skin/icons/help.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #help_reportBrokenSite {
     --menuitem-image: url("chrome://global/skin/icons/lightbulb.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #feedbackPage {
     --menuitem-image: url("../icons/send.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #helpSafeMode {
     --menuitem-image: url("chrome://devtools/skin/images/debugging-workers.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #troubleShooting {
     --menuitem-image: url("chrome://global/skin/icons/more.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #help_reportSiteIssue {
     --menuitem-image: url("chrome://global/skin/icons/lightbulb.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_HelpPopup_reportPhishingtoolmenu {
     --menuitem-image: url("chrome://global/skin/icons/warning.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #menu_HelpPopup_reportPhishingErrortoolmenu {
     --menuitem-image: url("../icons/checkmark-circle.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #helpSwitchDevice {
     --menuitem-image: url("../icons/add-device.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.global_menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.global_menu")) {
   #aboutName {
     --menuitem-image: url("chrome://global/skin/icons/info.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   /*= organizeButtonPopup ======================================================*/
   #newbookmark {
     --menuitem-image: url("chrome://browser/skin/bookmark.svg");
@@ -3522,77 +3522,77 @@
   /*= viewMenuPopup ============================================================*/
   /*= maintenanceButtonPopup ===================================================*/
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) and (-moz-pref("userChrome.icon.menu.full")) {
   #orgRedo {
     --menuitem-image: url("../icons/redo.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgCut {
     --menuitem-image: url("../icons/edit-cut.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgCopy {
     --menuitem-image: url("../icons/edit-copy.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgPaste {
     --menuitem-image: url("../icons/edit-paste.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgDelete {
     --menuitem-image: url("chrome://global/skin/icons/delete.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgSelectAll {
     --menuitem-image: url("../icons/select-all-on.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #orgClose {
     --menuitem-image: url("chrome://global/skin/icons/close.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #viewColumns {
     --menuitem-image: url("chrome://global/skin/icons/columnpicker.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #viewSort {
     --menuitem-image: url("../icons/text-sort-ascending.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #backupBookmarks {
     --menuitem-image: url("../icons/datastore.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") and (-moz-bool-pref: "userChrome.icon.menu.full") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) and (-moz-pref("userChrome.icon.menu.full")) {
   #fileRestoreMenu {
     --menuitem-image: url("../icons/datarestore.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #fileImport {
     --menuitem-image: url("../icons/toolbarButton-download.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #fileExport {
     --menuitem-image: url("../icons/toolbarButton-upload.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") and (-moz-bool-pref: "userChrome.icon.library") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) and (-moz-pref("userChrome.icon.library")) {
   #browserImport {
     --menuitem-image: url("chrome://browser/skin/import.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.1-25px_stroke") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.1-25px_stroke")) {
   #firefox-view-button {
     list-style-image: url("../icons/firefox-view.svg") !important;
   }
@@ -3612,12 +3612,12 @@
     content: url("../icons/developer.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenu-restart-button {
     list-style-image: url("../icons/refresh-cw.svg") !important;
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   #menu_FileRestartItem {
     --menuitem-image: url("../icons/refresh-cw.svg");
   }
@@ -3628,7 +3628,7 @@
     --menuitem-image: url("../icons/private-favicon.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #appMenuNewIdentity {
     list-style-image: url("chrome://browser/skin/new_identity.svg");
   }
@@ -3639,7 +3639,7 @@
     list-style-image: url("chrome://browser/skin/onion.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   #menu_newIdentity {
     --menuitem-image: url("chrome://browser/skin/new_identity.svg");
   }
@@ -3650,7 +3650,7 @@
     --menuitem-image: url("chrome://browser/skin/onion.svg");
   }
 }
-@media not (-moz-bool-pref: "userChrome.icon.disabled") {
+@media not (-moz-pref("userChrome.icon.disabled")) {
   #ssbPageAction-image {
     list-style-image: url("../icons/pwa-install.svg");
   }
@@ -3658,7 +3658,7 @@
     list-style-image: url("../icons/pwa-launch.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.panel") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.panel")) {
   #rebootappmenu {
     list-style-image: url("../icons/refresh-cw.svg");
   }
@@ -3675,7 +3675,7 @@
     list-style-image: url("../icons/pwa-launch.svg");
   }
 }
-@media (not (-moz-bool-pref: "userChrome.icon.disabled")) and (-moz-bool-pref: "userChrome.icon.menu") {
+@media (not (-moz-pref("userChrome.icon.disabled"))) and (-moz-pref("userChrome.icon.menu")) {
   #toggle_sharemode {
     --menuitem-image: url("chrome://branding/content/about-logo-private.png");
   }

--- a/chrome/modules/horizontal_tabs/wavefox_drag_space.css
+++ b/chrome/modules/horizontal_tabs/wavefox_drag_space.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.DragSpace.Left.Disabled")
+@media (-moz-pref("userChrome.DragSpace.Left.Disabled"))
 {
     .titlebar-spacer[type="pre-tabs"]
     {
@@ -6,7 +6,7 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.DragSpace.Right.Disabled")
+@media (-moz-pref("userChrome.DragSpace.Right.Disabled"))
 {
     .titlebar-spacer[type="post-tabs"]
     {
@@ -14,7 +14,7 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.DragSpace.Top.Windowed.Enabled")
+@media (-moz-pref("userChrome.DragSpace.Top.Windowed.Enabled"))
 {
     :root[sizemode="normal"]
     {
@@ -22,7 +22,7 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.DragSpace.Top.Maximized.Enabled")
+@media (-moz-pref("userChrome.DragSpace.Top.Maximized.Enabled"))
 {
     :root[sizemode="maximized"]
     {
@@ -30,7 +30,7 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.DragSpace.Top.Fullscreen.Enabled")
+@media (-moz-pref("userChrome.DragSpace.Top.Fullscreen.Enabled"))
 {
     :root[sizemode="fullscreen"]
     {

--- a/chrome/modules/horizontal_tabs/wavefox_one_line.css
+++ b/chrome/modules/horizontal_tabs/wavefox_one_line.css
@@ -1,7 +1,7 @@
-@media (-moz-bool-pref: "userChrome.OneLine.TabBarFirst.Enabled") or
-       (-moz-bool-pref: "userChrome.OneLine.NavBarFirst.Enabled")
+@media (-moz-pref("userChrome.OneLine.TabBarFirst.Enabled")) or
+       (-moz-pref("userChrome.OneLine.NavBarFirst.Enabled"))
 {
-    @media (-moz-bool-pref: "userChrome.OneLine.TabBarFirst.Enabled")
+    @media (-moz-pref("userChrome.OneLine.TabBarFirst.Enabled"))
     {
         #navigator-toolbox
         {
@@ -19,7 +19,7 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.OneLine.NavBarFirst.Enabled")
+    @media (-moz-pref("userChrome.OneLine.NavBarFirst.Enabled"))
     {
         #navigator-toolbox
         {

--- a/chrome/modules/horizontal_tabs/wavefox_rounded_web_page.css
+++ b/chrome/modules/horizontal_tabs/wavefox_rounded_web_page.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.WebPage.Rounding.Enabled")
+@media (-moz-pref("userChrome.WebPage.Rounding.Enabled"))
 {
     :root:not([inFullscreen], [inDOMFullscreen])
     {
@@ -16,9 +16,9 @@
             overflow: hidden !important;
             clip-path: border-box !important;
 
-            @media (-moz-bool-pref: "userChrome.Tabs.TabsOnBottom.Enabled")   or
-                   (-moz-bool-pref: "userChrome.OneLine.TabBarFirst.Enabled") or
-                   (-moz-bool-pref: "userChrome.OneLine.NavBarFirst.Enabled")
+            @media (-moz-pref("userChrome.Tabs.TabsOnBottom.Enabled"))   or
+                   (-moz-pref("userChrome.OneLine.TabBarFirst.Enabled")) or
+                   (-moz-pref("userChrome.OneLine.NavBarFirst.Enabled"))
             {
                 margin-block-start: 8px !important;
             }

--- a/chrome/modules/horizontal_tabs/wavefox_selected_tab_indicator.css
+++ b/chrome/modules/horizontal_tabs/wavefox_selected_tab_indicator.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.Tabs.SelectedTabIndicator.Enabled")
+@media (-moz-pref("userChrome.Tabs.SelectedTabIndicator.Enabled"))
 {
     .tabbrowser-tab[visuallyselected] .tab-loading-burst
     {

--- a/chrome/modules/horizontal_tabs/wavefox_tab_separators.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tab_separators.css
@@ -1,5 +1,5 @@
-@media (-moz-bool-pref: "userChrome.TabSeparators.Saturation.Low.Enabled")    or
-       (-moz-bool-pref: "userChrome.TabSeparators.Saturation.Medium.Enabled")
+@media (-moz-pref("userChrome.TabSeparators.Saturation.Low.Enabled"))    or
+       (-moz-pref("userChrome.TabSeparators.Saturation.Medium.Enabled"))
 {
     .tab-stack
     {
@@ -48,7 +48,7 @@
         opacity: var(--separators-color-saturation) !important;
     }
 
-    @media (-moz-bool-pref: "userChrome.TabSeparators.Saturation.Low.Enabled")
+    @media (-moz-pref("userChrome.TabSeparators.Saturation.Low.Enabled"))
     {
         :root
         {
@@ -56,7 +56,7 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.TabSeparators.Saturation.Medium.Enabled")
+    @media (-moz-pref("userChrome.TabSeparators.Saturation.Medium.Enabled"))
     {
         :root
         {
@@ -64,14 +64,14 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option12.Enabled"))
     {
         .tab-stack::before
         {

--- a/chrome/modules/horizontal_tabs/wavefox_tab_shadows.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tab_shadows.css
@@ -1,16 +1,16 @@
-@media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled")      or
-       (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled")   or
-       (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled")     or
-       (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+@media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled"))      or
+       (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled"))   or
+       (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled"))     or
+       (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
 {
-    @media not ((-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled"))
+    @media not ((-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option12.Enabled")))
     {
         @media (prefers-color-scheme: light)
         {
@@ -33,29 +33,29 @@
 
                 /* ---------- Blur ---------- */
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Borders.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Borders.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-blur: 1px;
                 }
 
                 /* ---------- Saturation ---------- */
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 10%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 25%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 50%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 100%;
                 }
@@ -77,14 +77,14 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option12.Enabled"))
     {
         @media (prefers-color-scheme: light)
         {
@@ -108,29 +108,29 @@
 
                 /* ---------- Blur ---------- */
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Borders.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Borders.Enabled"))
                 {
                     --wavefox-at-tab-shadow-blur: 2px;
                 }
 
                 /* ---------- Saturation ---------- */
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Low.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 10%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.Medium.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 25%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.High.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 50%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+                @media (-moz-pref("userChrome.LightTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 100%;
                 }
@@ -168,19 +168,19 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled")      or
-       (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled")   or
-       (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled")     or
-       (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+@media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled"))      or
+       (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled"))   or
+       (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled"))     or
+       (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
 {
-    @media not ((-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled"))
+    @media not ((-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option12.Enabled")))
     {
         @media (prefers-color-scheme: dark)
         {
@@ -203,29 +203,29 @@
 
                 /* ---------- Blur ---------- */
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Borders.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Borders.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-blur: 1px;
                 }
 
                 /* ---------- Saturation ---------- */
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 25%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 50%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 75%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
                 {
                     --wavefox-ft-tab-shadow-saturation: 100%;
                 }
@@ -247,14 +247,14 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-           (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-           (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+           (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+           (-moz-pref("userChrome.Tabs.Option12.Enabled"))
     {
         @media (prefers-color-scheme: dark)
         {
@@ -278,29 +278,29 @@
 
                 /* ---------- Blur ---------- */
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Borders.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Borders.Enabled"))
                 {
                     --wavefox-at-tab-shadow-blur: 2px;
                 }
 
                 /* ---------- Saturation ---------- */
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Low.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 25%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.Medium.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 50%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.High.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 75%;
                 }
 
-                @media (-moz-bool-pref: "userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled")
+                @media (-moz-pref("userChrome.DarkTheme.Tabs.Shadows.Saturation.VeryHigh.Enabled"))
                 {
                     --wavefox-at-tab-shadow-saturation: 100%;
                 }

--- a/chrome/modules/horizontal_tabs/wavefox_tabs.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tabs.css
@@ -71,14 +71,14 @@
 
 /* ---------------------------------------- Floating tabs ---------------------------------------- */
 
-@media (-moz-bool-pref: "userChrome.Tabs.Option1.Enabled") or
-       (-moz-bool-pref: "userChrome.Tabs.Option2.Enabled") or
-       (-moz-bool-pref: "userChrome.Tabs.Option3.Enabled") or
-       (-moz-bool-pref: "userChrome.Tabs.Option4.Enabled")
+@media (-moz-pref("userChrome.Tabs.Option1.Enabled")) or
+       (-moz-pref("userChrome.Tabs.Option2.Enabled")) or
+       (-moz-pref("userChrome.Tabs.Option3.Enabled")) or
+       (-moz-pref("userChrome.Tabs.Option4.Enabled"))
 {
     /* -------------------- Tab shapes -------------------- */
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option1.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option1.Enabled"))
     {
         :root
         {
@@ -86,7 +86,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option2.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option2.Enabled"))
     {
         :root
         {
@@ -94,7 +94,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option3.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option3.Enabled"))
     {
         :root
         {
@@ -102,7 +102,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option4.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option4.Enabled"))
     {
         :root
         {
@@ -113,18 +113,18 @@
 
 /* ---------------------------------------- Attached tabs ---------------------------------------- */
 
-@media (-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-       (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-       (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-       (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-       (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-       (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-       (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-       (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled")
+@media (-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+       (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+       (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+       (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+       (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+       (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+       (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+       (-moz-pref("userChrome.Tabs.Option12.Enabled"))
 {
     /* -------------------- Tab shapes -------------------- */
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option5.Enabled"))
     {
         :root
         {
@@ -134,7 +134,7 @@
         }
     }
 
-    @media (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option6.Enabled"))
     {
         :root
         {
@@ -144,7 +144,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option7.Enabled"))
     {
         :root
         {
@@ -154,7 +154,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option8.Enabled"))
     {
         :root
         {
@@ -164,7 +164,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option9.Enabled"))
     {
         :root
         {
@@ -174,7 +174,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option10.Enabled"))
     {
         :root
         {
@@ -184,7 +184,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option11.Enabled"))
     {
         :root
         {
@@ -194,7 +194,7 @@
         }
     }
     
-    @media (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled")
+    @media (-moz-pref("userChrome.Tabs.Option12.Enabled"))
     {
         :root
         {
@@ -311,7 +311,7 @@
 
     /* -------------------- Tab Groups (Alpha) -------------------- */
 
-    @media (-moz-bool-pref: "browser.tabs.groups.enabled")
+    @media (-moz-pref("browser.tabs.groups.enabled"))
     {
         .tab-group-line
         {

--- a/chrome/modules/horizontal_tabs/wavefox_tabs_background_inactive.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tabs_background_inactive.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.Tabs.Background.Inactive.Enabled")
+@media (-moz-pref("userChrome.Tabs.Background.Inactive.Enabled"))
 {
     .tabbrowser-tab:not([visuallyselected])
     {

--- a/chrome/modules/horizontal_tabs/wavefox_tabs_on_bottom.css
+++ b/chrome/modules/horizontal_tabs/wavefox_tabs_on_bottom.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.Tabs.TabsOnBottom.Enabled")
+@media (-moz-pref("userChrome.Tabs.TabsOnBottom.Enabled"))
 {
     /* -------------------- Title Bar -------------------- */
 
@@ -67,14 +67,14 @@
 
     /* -------------------- Shadows -------------------- */
     
-    @media not ((-moz-bool-pref: "userChrome.Tabs.Option5.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option6.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option7.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option8.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option9.Enabled")  or
-                (-moz-bool-pref: "userChrome.Tabs.Option10.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option11.Enabled") or
-                (-moz-bool-pref: "userChrome.Tabs.Option12.Enabled"))
+    @media not ((-moz-pref("userChrome.Tabs.Option5.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option6.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option7.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option8.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option9.Enabled"))  or
+                (-moz-pref("userChrome.Tabs.Option10.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option11.Enabled")) or
+                (-moz-pref("userChrome.Tabs.Option12.Enabled")))
     {
         #TabsToolbar
         {

--- a/chrome/modules/horizontal_tabs/wavefox_toolbar_transparency.css
+++ b/chrome/modules/horizontal_tabs/wavefox_toolbar_transparency.css
@@ -1,6 +1,6 @@
-@media (-moz-bool-pref: "userChrome.Toolbar.Transparency.Low.Enabled")    or
-       (-moz-bool-pref: "userChrome.Toolbar.Transparency.Medium.Enabled") or
-       (-moz-bool-pref: "userChrome.Toolbar.Transparency.High.Enabled")
+@media (-moz-pref("userChrome.Toolbar.Transparency.Low.Enabled"))    or
+       (-moz-pref("userChrome.Toolbar.Transparency.Medium.Enabled")) or
+       (-moz-pref("userChrome.Toolbar.Transparency.High.Enabled"))
 {
     :root:not([lwtheme])
     {
@@ -9,17 +9,17 @@
         --toolbarbutton-hover-background: color-mix(in srgb, currentColor 17%, transparent) !important;
         --toolbarbutton-active-background: color-mix(in srgb, currentColor 30%, transparent) !important;
         
-        @media (-moz-bool-pref: "userChrome.Toolbar.Transparency.Low.Enabled")
+        @media (-moz-pref("userChrome.Toolbar.Transparency.Low.Enabled"))
         {
             --toolbar-transparency-level: 25%;
         }
         
-        @media (-moz-bool-pref: "userChrome.Toolbar.Transparency.Medium.Enabled")
+        @media (-moz-pref("userChrome.Toolbar.Transparency.Medium.Enabled"))
         {
             --toolbar-transparency-level: 50%;
         }
         
-        @media (-moz-bool-pref: "userChrome.Toolbar.Transparency.High.Enabled")
+        @media (-moz-pref("userChrome.Toolbar.Transparency.High.Enabled"))
         {
             --toolbar-transparency-level: 75%;
         }
@@ -37,7 +37,7 @@
     }
 }
 
-@media (-moz-bool-pref: "userChrome.Toolbar.Transparency.VeryHigh.Enabled")
+@media (-moz-pref("userChrome.Toolbar.Transparency.VeryHigh.Enabled"))
 {
     :root:not([lwtheme])
     {

--- a/chrome/modules/horizontal_tabs/wavefox_transparency_on_linux.css
+++ b/chrome/modules/horizontal_tabs/wavefox_transparency_on_linux.css
@@ -1,7 +1,7 @@
-@media (-moz-bool-pref: "userChrome.Linux.Transparency.Low.Enabled")      or
-       (-moz-bool-pref: "userChrome.Linux.Transparency.Medium.Enabled")   or
-       (-moz-bool-pref: "userChrome.Linux.Transparency.High.Enabled")     or
-       (-moz-bool-pref: "userChrome.Linux.Transparency.VeryHigh.Enabled")
+@media (-moz-pref("userChrome.Linux.Transparency.Low.Enabled"))      or
+       (-moz-pref("userChrome.Linux.Transparency.Medium.Enabled"))   or
+       (-moz-pref("userChrome.Linux.Transparency.High.Enabled"))     or
+       (-moz-pref("userChrome.Linux.Transparency.VeryHigh.Enabled"))
 {
     :root
     {
@@ -12,22 +12,22 @@
             --toolbox-background-color: InActiveCaption;
         }
 
-        @media (-moz-bool-pref: "userChrome.Linux.Transparency.Low.Enabled")
+        @media (-moz-pref("userChrome.Linux.Transparency.Low.Enabled"))
         {
             --toolbox-transparency: 25%;
         }
 
-        @media (-moz-bool-pref: "userChrome.Linux.Transparency.Medium.Enabled")
+        @media (-moz-pref("userChrome.Linux.Transparency.Medium.Enabled"))
         {
             --toolbox-transparency: 50%;
         }
 
-        @media (-moz-bool-pref: "userChrome.Linux.Transparency.High.Enabled")
+        @media (-moz-pref("userChrome.Linux.Transparency.High.Enabled"))
         {
             --toolbox-transparency: 75%;
         }
 
-        @media (-moz-bool-pref: "userChrome.Linux.Transparency.VeryHigh.Enabled")
+        @media (-moz-pref("userChrome.Linux.Transparency.VeryHigh.Enabled"))
         {
             --toolbox-transparency: 100%;
         }

--- a/chrome/modules/horizontal_tabs/wavefox_transparency_on_windows.css
+++ b/chrome/modules/horizontal_tabs/wavefox_transparency_on_windows.css
@@ -1,4 +1,4 @@
-@media (-moz-bool-pref: "userChrome.Windows.Transparency.Enabled")
+@media (-moz-pref("userChrome.Windows.Transparency.Enabled"))
 {
     :root[customtitlebar]:not([lwtheme])
     {

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -2,21 +2,21 @@
 
 /* ---------- Horizontal Tabs ---------- */
 
-@import "modules/horizontal_tabs/wavefox_tabs.css"                      layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_tabs_background_inactive.css"  layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_selected_tab_indicator.css"    layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_tab_media_icons_and_text.css"  layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_toolbar_buttons.css"           layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_tab_separators.css"            layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_tab_shadows.css"               layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_drag_space.css"                layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_toolbar_transparency.css"      layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_tabs_on_bottom.css"            layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
-@import "modules/horizontal_tabs/wavefox_one_line.css"                  layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.verticalTabs");
+@import "modules/horizontal_tabs/wavefox_tabs.css"                      layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_tabs_background_inactive.css"  layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_selected_tab_indicator.css"    layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_tab_media_icons_and_text.css"  layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_toolbar_buttons.css"           layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_tab_separators.css"            layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_tab_shadows.css"               layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_drag_space.css"                layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_toolbar_transparency.css"      layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_tabs_on_bottom.css"            layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
+@import "modules/horizontal_tabs/wavefox_one_line.css"                  layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.verticalTabs"));
 @import "modules/horizontal_tabs/wavefox_transparency_on_windows.css"   layer(BasicPriority) /* supports() */     (-moz-platform: windows);
 @import "modules/horizontal_tabs/wavefox_transparency_on_linux.css"     layer(BasicPriority) /* supports() */     (-moz-platform: linux);
-@import "modules/horizontal_tabs/wavefox_rounded_web_page.css"          layer(BasicPriority) /* supports() */ not (-moz-bool-pref: "sidebar.revamp");
-@import "Lepton_Icons/icons/Lepton_Icons.css"                           layer(BasicPriority) /* supports() */     (-moz-bool-pref: "userChrome.Menu.Icons.LeptonIcons.Enabled");
+@import "modules/horizontal_tabs/wavefox_rounded_web_page.css"          layer(BasicPriority) /* supports() */ not (-moz-pref("sidebar.revamp"));
+@import "Lepton_Icons/icons/Lepton_Icons.css"                           layer(BasicPriority) /* supports() */     (-moz-pref("userChrome.Menu.Icons.LeptonIcons.Enabled"));
 
 /* ---------------------------------------- Third-party styles (Maximum priority) ---------------------------------------- */
  


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1946764 (mentioned in https://github.com/QNetITQ/WaveFox/issues/211#issuecomment-2653071930) seems to have landed in nightly. It removes `-moz-bool-pref: "foo"` and adds `-moz-pref("foo")`.

I replaced `-moz-bool-pref: ("[^"]+")` with `-moz-pref($1)`. Unfortunately, VS Code's CSS parser doesn't like `-moz-pref("foo")`.