### PR TITLE
Add newpage Transparency

### DIFF
--- a/chrome/modules/Third-party/newtab_transparency.css
+++ b/chrome/modules/Third-party/newtab_transparency.css
@@ -1,0 +1,11 @@
+@media (-moz-bool-pref: "userChrome.newtab.Transparency.Enabled")
+{
+    /* newtab page */
+    @-moz-document url(about:blank), url(about:newtab), url(about:home) {
+        :root {
+        --in-content-page-background: transparent !important;
+        --in-content-box-background: transparent !important;
+        --newtab-background-color: transparent !important;
+        }
+    }
+}

--- a/chrome/modules/Third-party/website_transparency.css
+++ b/chrome/modules/Third-party/website_transparency.css
@@ -1,0 +1,33 @@
+@media (-moz-bool-pref: "userChrome.website.Transparency.Low.Enabled")      or
+       (-moz-bool-pref: "userChrome.website.Transparency.Medium.Enabled")   or
+       (-moz-bool-pref: "userChrome.website.Transparency.High.Enabled")     or
+       (-moz-bool-pref: "userChrome.website.Transparency.VeryHigh.Enabled")
+{
+    
+    :root:not([lwtheme]) {
+        @media (-moz-bool-pref: "userChrome.website.Transparency.Low.Enabled")
+        {
+            --newtab-transparency-level: 25%;
+        }
+        
+        @media (-moz-bool-pref: "userChrome.website.Transparency.Medium.Enabled")
+        {
+            --newtab-transparency-level: 50%;
+        }
+        
+        @media (-moz-bool-pref: "userChrome.website.Transparency.High.Enabled")
+        {
+            --newtab-transparency-level: 75%;
+        }
+
+        @media (-moz-bool-pref: "userChrome.website.Transparency.VeryHigh.Enabled")
+        {
+            --newtab-transparency-level: 100%;
+        }
+
+        #browser:not(.browser-toolbox-background) {
+            background-color: color-mix(in srgb, #2B2A33, transparent var(--newtab-transparency-level)) !important;
+            --tabpanel-background-color: transparent !important;
+        }
+    }
+}

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -19,3 +19,5 @@
 @import "Lepton_Icons/icons/Lepton_Icons.css"                           layer(BasicPriority) /* supports() */     (-moz-bool-pref: "userChrome.Menu.Icons.LeptonIcons.Enabled");
 
 /* ---------------------------------------- Third-party styles (Maximum priority) ---------------------------------------- */
+
+@import "modules/Third-party/website_transparency.css"                  layer(BasicPriority);

--- a/chrome/userContent.css
+++ b/chrome/userContent.css
@@ -1,0 +1,3 @@
+/* ---------------------------------------- Third-party styles (Maximum priority) ---------------------------------------- */
+
+@import "modules/Third-party/newtab_transparency.css"                       layer(BasicPriority);


### PR DESCRIPTION
This adds the option to add general website transparency using userChrome.website.Transparency.Low/Medium/High/VeryHigh ,
and the transparency of the "about:newtab" site using userChrome.newtab.Transparency.Enabled